### PR TITLE
Add root directory command line switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Simple, standalone, static content server for developers. Its aim is to provide 
 ## Options
 
 * `--port` | `-p` - Specifies port used for hosting server. Default value: 8080
+* `--dir` | `-d` - Specifies root directory. Default is the current directory
 * `--help` - Displays list of options
 
 


### PR DESCRIPTION
This change adds a -d command line switch to set the base directory for the empty url.

It also adds handling for when the getf "%s" route is called with a null string (which may only happen in the debugger on Windows at startup).